### PR TITLE
Raise exception when handling untrusted SSL certs.

### DIFF
--- a/lib/link_oracle/request.rb
+++ b/lib/link_oracle/request.rb
@@ -52,6 +52,8 @@ class LinkOracle
       c
     rescue Curl::Err::HostResolutionError
       raise ServerNotFound
+    rescue Curl::Err::SSLCACertificateError
+      raise BadSslCertificate
     end
 
     def error_class
@@ -75,4 +77,5 @@ class LinkOracle
   class BadThingsHappened < StandardError; end
   class InvalidUrl < StandardError; end
   class ParsingError < StandardError; end
+  class BadSslCertificate < StandardError ; end
 end

--- a/lib/link_oracle/version.rb
+++ b/lib/link_oracle/version.rb
@@ -1,3 +1,3 @@
 class LinkOracle
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end


### PR DESCRIPTION
this will make it so orare can handle the following crash more gracefully: http://socialchorus-shootie.appspot.com/sumeet.agarwal/6262207541149696

the reason i'm raising this exception in link_oracle is so orare doesn't have to know anything about curb.

this goes with https://github.com/socialchorus/orare/pull/3
