### PR TITLE
Handle another untrusted SSL cert exception from Curb.

### DIFF
--- a/lib/link_oracle/request.rb
+++ b/lib/link_oracle/request.rb
@@ -52,7 +52,7 @@ class LinkOracle
       c
     rescue Curl::Err::HostResolutionError
       raise ServerNotFound
-    rescue Curl::Err::SSLCACertificateError
+    rescue Curl::Err::SSLCACertificateError, Curl::Err::SSLPeerCertificateError
       raise BadSslCertificate
     end
 

--- a/spec/link_oracle/request_spec.rb
+++ b/spec/link_oracle/request_spec.rb
@@ -73,10 +73,13 @@ describe LinkOracle::Request do
 
       context "when the server's SSL certificate is untrusted" do
         it "raises BadSslCertificate" do
-          stub_request(:get, url).to_raise(Curl::Err::SSLCACertificateError)
-          expect do
-            requester.parsed_url
-           end.to raise_error(LinkOracle::BadSslCertificate)
+          [Curl::Err::SSLCACertificateError,
+           Curl::Err::SSLPeerCertificateError].each do |exception_class|
+            stub_request(:get, url).to_raise(exception_class)
+            expect do
+              requester.parsed_url
+             end.to raise_error(LinkOracle::BadSslCertificate)
+          end
         end
       end
 


### PR DESCRIPTION
so i went to test on staging, and there's a different exception raised there (probably due to ssl certs being configured differently on heroku).
